### PR TITLE
Visualization changes for PDFs

### DIFF
--- a/interface_utils.py
+++ b/interface_utils.py
@@ -25,7 +25,9 @@ def load_document(doc_filename):
 
 @st.cache_resource
 def get_spacy_pipeline():
-    return spacy.load("en_core_sci_md", exclude=["tagger", "parser", "ner", "lemmatizer"])
+    return spacy.load(
+        "en_core_web_sm", exclude=["tagger", "parser", "ner", "lemmatizer", "attribute_ruler"]
+    )
 
 
 def infer_tagging_models(doc: Document) -> list[str]:

--- a/interface_utils.py
+++ b/interface_utils.py
@@ -14,7 +14,6 @@ from papermage_components.constants import MAT_IE_TYPES
 
 PARSED_PAPER_FOLDER = "data/Midyear_Review_Papers_Parsed"
 CUSTOM_MODELS_KEY = "custom_models"
-SELECTABLE_FIELDS = {"reading_order_sections", TablesFieldName}
 
 
 @st.cache_resource
@@ -60,13 +59,13 @@ def get_entity_types(model_names):
     return all_entity_types
 
 
-def plot_selectable_regions(document, page_number, exclude_entities=None):
+def plot_selectable_regions(document, page_number, selectable_layers, exclude_entities=None):
     exclude_entities = exclude_entities if exclude_entities is not None else []
     page = document.pages[page_number]
     page_image = page.images[0]
 
     all_entities = []
-    for field in SELECTABLE_FIELDS:
+    for field in selectable_layers:
         entities = getattr(page, field)
         all_entities.extend([entity for entity in entities if entity not in exclude_entities])
 
@@ -91,7 +90,12 @@ def highlight_section_on_page(document, page_number, section_name, paragraph):
         and e.metadata["paragraph_reading_order"] == paragraph
     ]
 
-    page_image = plot_selectable_regions(document, page_number, exclude_entities=section_entities)
+    page_image = plot_selectable_regions(
+        document,
+        page_number,
+        selectable_layers=["reading_order_sections", TablesFieldName],
+        exclude_entities=section_entities,
+    )
 
     highlighted = plot_entities_on_page(
         page_image,
@@ -104,14 +108,19 @@ def highlight_section_on_page(document, page_number, section_name, paragraph):
     return highlighted
 
 
-def highlight_table_on_page(document, page_number, table_entities):
+def highlight_entities_on_page(document, page_number, entities, selectable_layers):
     page = document.pages[page_number]
 
-    page_image = plot_selectable_regions(document, page_number, exclude_entities=table_entities)
+    page_image = plot_selectable_regions(
+        document,
+        page_number,
+        selectable_layers=selectable_layers,
+        exclude_entities=entities,
+    )
 
     highlighted = plot_entities_on_page(
         page_image,
-        table_entities,
+        entities,
         box_width=2,
         box_alpha=0.2,
         box_color="green",

--- a/pages/2_Annotations_View.py
+++ b/pages/2_Annotations_View.py
@@ -163,11 +163,18 @@ with doc_vis_column:
             focus_document, focus_page, section_name, paragraph
         )
     elif isinstance(section_name, int):
-        highlighted_image = highlight_table_on_page(
-            focus_document, focus_page, [focus_document.tables[section_name]]
+        highlighted_image = highlight_entities_on_page(
+            focus_document,
+            focus_page,
+            [focus_document.tables[section_name]],
+            selectable_layers=["reading_order_sections", TablesFieldName],
         )
     else:
-        highlighted_image = plot_selectable_regions(focus_document, focus_page)
+        highlighted_image = plot_selectable_regions(
+            focus_document,
+            focus_page,
+            selectable_layers=["reading_order_sections", TablesFieldName],
+        )
     page_width, page_height = highlighted_image.pilimage.size
     ratio = page_height / page_width
 

--- a/pages/2_Annotations_View.py
+++ b/pages/2_Annotations_View.py
@@ -154,21 +154,20 @@ with sections_column:
 
 
 with doc_vis_column:
-    st.write("Click a section of text to view the annotations on it:")
+    st.write(
+        "Click a section of text to view the annotations on it. Light blue boxes indicate clickable"
+        " areas that have been annotated. Green boxes indicate the current section of focus."
+    )
     if isinstance(section_name, str):
         highlighted_image = highlight_section_on_page(
             focus_document, focus_page, section_name, paragraph
         )
     elif isinstance(section_name, int):
-        highlighted_image = plot_entities_on_page(
-            focus_document.pages[focus_page].images[0],
-            entities=[focus_document.tables[section_name]],
-            box_width=2,
-            box_alpha=0.2,
-            box_color="green",
+        highlighted_image = highlight_table_on_page(
+            focus_document, focus_page, [focus_document.tables[section_name]]
         )
     else:
-        highlighted_image = focus_document.pages[focus_page].images[0]
+        highlighted_image = plot_selectable_regions(focus_document, focus_page)
     page_width, page_height = highlighted_image.pilimage.size
     ratio = page_height / page_width
 

--- a/pages/3_Inspection_View.py
+++ b/pages/3_Inspection_View.py
@@ -14,7 +14,6 @@ from papermage_components.constants import (
 )
 from papermage_components.utils import (
     visualize_highlights,
-    visualize_matIE_annotations,
     get_table_image,
 )
 from interface_utils import *
@@ -27,25 +26,21 @@ BOX_PADDING = 0.01
 file_options = os.listdir(PARSED_PAPER_FOLDER)
 
 
-def visualize_table_with_boxes(table, doc, include_tokens):
-    table_box = table.boxes[0]
-    table_boxes = [Box.from_json(b) for b in table.metadata["cell_boxes"]]
-    vis_entity = plot_entities_on_page(
-        doc.pages[table_box.page].images[0],
-        entities=[Entity(boxes=table_boxes)],
-        box_width=2,
-        box_color="cornflowerblue",
-    )
-    if include_tokens:
-        vis_entity = plot_entities_on_page(
-            vis_entity, entities=table.tokens, box_width=2, box_color="red"
-        )
-    vis_entity = get_table_image(table, doc, vis_entity.pilimage)
-    return vis_entity
+LAYER_EXCLUDES = ["symbols", "images", "metadata"]
+
+focus_entities = None
+
+
+def get_layers_with_boxes(document) -> list[str]:
+    return [
+        layer
+        for layer in document.layers
+        if layer not in LAYER_EXCLUDES and all([e.boxes for e in getattr(document, layer)])
+    ]
 
 
 with st.sidebar:  # .form("File selector"):
-    st.write("Select a pre-parsed file whose results to display")
+    st.write("Select a parsed file whose results to display")
     focus_file = st.session_state.get("focus_document")
     file_selector = st.selectbox(
         "Parsed file",
@@ -55,7 +50,12 @@ with st.sidebar:  # .form("File selector"):
     st.session_state["focus_document"] = file_selector
     focus_document = load_document(file_selector)
 
-doc_vis_column, sections_column = st.columns([0.4, 0.6])
+    st.divider()
+    st.write("Select layer from PaperMage pipeline to visualize:")
+    focus_layer = st.selectbox("Layer", options=get_layers_with_boxes(focus_document))
+
+
+doc_vis_column, inspection_column = st.columns([0.4, 0.6])
 with doc_vis_column:
     focus_page = st.slider(
         label="Select the document page to view",
@@ -66,58 +66,26 @@ with doc_vis_column:
     )
     focus_page = focus_page - 1
 
-clicked_section = st.session_state.get("clicked_section_inspect", None)
-if (
-    clicked_section is None
-    or clicked_section[0] != file_selector
-    or clicked_section[1] != focus_page
-):
-    st.session_state["clicked_section_inspect"] = None
-    section_name = None
-    paragraph = None
-else:
-    section_name = clicked_section[2]
-    paragraph = clicked_section[3]
+    st.write("Click a section of text to view the annotations on it:")
 
-with sections_column:
-    if isinstance(section_name, str):
-        section_entities = [
-            e
-            for e in focus_document.pages[focus_page].reading_order_sections
-            if e.metadata["section_name"] == section_name
-            and e.metadata["paragraph_reading_order"] == paragraph
-        ]
-        st.markdown(
-            f"## Section: {section_entities[0].metadata['section_name']}, paragraph "
-            f"{section_entities[0].metadata['paragraph_reading_order']}"
+    if (coords := st.session_state.get("clicked_coordinates")) and coords[2] == focus_page:
+        x, y, page = coords
+        focus_entities = focus_document.find(
+            Box(x - BOX_PADDING / 2, y - BOX_PADDING / 2, BOX_PADDING, BOX_PADDING, focus_page),
+            focus_layer,
+        )
+        highlighted_image = highlight_entities_on_page(
+            focus_document, focus_page, focus_entities, selectable_layers=[focus_layer]
+        )
+    else:
+        highlighted_image = plot_selectable_regions(
+            focus_document, focus_page, selectable_layers=[focus_layer]
         )
 
-        for entity in section_entities:
-            show_sentences = st.toggle("Show sentences instead of raw text")
-            if show_sentences:
-                for sentence in entity.sentences:
-                    st.write(sentence.text)
-            else:
-                st.write(entity.text)
-
-    # table by id
-    elif isinstance(section_name, int):
-        table = focus_document.tables[section_name]
-        st.write("### Parsed Table:")
-        st.dataframe(pd.DataFrame(table.metadata["table_dict"]), hide_index=True)
-        st.write("Raw Table Text:")
-        st.write(table.text)
-
-
-with doc_vis_column:
-    st.write("Click a section of text to view the annotations on it:")
-    highlighted_image = highlight_section_on_page(
-        focus_document, focus_page, section_name, paragraph
-    )
     page_width, page_height = highlighted_image.pilimage.size
     ratio = page_height / page_width
 
-    image_width = 726  # st_dimensions(key="doc_vis")["width"]
+    image_width = st_dimensions(key="doc_vis")["width"]
     image_height = image_width * ratio
 
     image_coords = streamlit_image_coordinates(
@@ -128,46 +96,24 @@ with doc_vis_column:
         x = image_coords["x"] / image_width
         y = image_coords["y"] / image_height
 
-        click_sections = focus_document.find(
-            Box(x - BOX_PADDING / 2, y - BOX_PADDING / 2, BOX_PADDING, BOX_PADDING, focus_page),
-            "reading_order_sections",
-        )
+        st.session_state["clicked_coordinates"] = (x, y, focus_page)
 
-        if click_sections:
-            section_name = click_sections[0].metadata["section_name"]
-            paragraph = click_sections[0].metadata["paragraph_reading_order"]
-            if st.session_state.get("clicked_section_inspect") != (
-                file_selector,
-                focus_page,
-                section_name,
-                paragraph,
-            ):
-                st.session_state["clicked_section_inspect"] = (
-                    file_selector,
-                    focus_page,
-                    section_name,
-                    paragraph,
-                )
-                st.rerun()
-        elif click_sections := focus_document.find(
-            Box(x - BOX_PADDING / 2, y - BOX_PADDING / 2, BOX_PADDING, BOX_PADDING, focus_page),
-            "tables",
-        ):
-            section_name = click_sections[0].id
-            paragraph = ""
-            if st.session_state.get("clicked_section_inspect") != (
-                file_selector,
-                focus_page,
-                section_name,
-                paragraph,
-            ):
-                st.session_state["clicked_section_inspect"] = (
-                    file_selector,
-                    focus_page,
-                    section_name,
-                    paragraph,
-                )
-                st.rerun()
-
-        else:
-            st.toast("No parsed content found at specified location!")
+with inspection_column:
+    if not focus_entities:
+        st.write("Select an entity on the PDF to visualize its contents.")
+    else:
+        with st.container(border=True):
+            st.write("### Entity Images")
+            for entity in focus_entities:
+                entity_image = get_table_image(entity, focus_document)
+                st.image(entity_image)
+        with st.container(border=True):
+            st.write("### Entity Text")
+            show_sentences = st.toggle("Split into sentences")
+            for entity in focus_entities:
+                if show_sentences:
+                    for sentence in entity.sentences:
+                        st.write(sentence.text)
+                else:
+                    st.write(focus_entities[0].text)
+                st.divider()


### PR DESCRIPTION
This PR:
- adds highlighted selectable regions to the PDF in the annotations view. Users now have a sense of all clickable regions that have been analyzed.
- Changes the Inspection view to allow inspection of arbitrary layers, and visualizes the images/sentences inside particular bounding boxes. 
- makes some miscellaneous changes: renaming functions to reflect their actual degree of genericity, swapping out the placeholder spacy pipeline used for visualization to achieve faster loads.