### PR TITLE
Allow to configure GROBID and chemdataext via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,26 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
 FROM python:3.10-bullseye AS build
 
-RUN pip install --upgrade pip
-RUN mkdir /app
 WORKDIR /app
 
-
-RUN pip install 'papermage[dev,predictors,visualizers]@git+https://github.com/gsireesh/papermage.git@ad_hoc_fixes'
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir 'papermage[dev,predictors,visualizers]@git+https://github.com/gsireesh/papermage.git@ad_hoc_fixes'
 
 COPY requirements.txt /app/requirements.txt
-RUN pip install -r requirements.txt
-
+RUN pip install --no-cache-dir -r requirements.txt
 RUN python -m spacy download en_core_web_sm
 
 FROM python:3.10-slim-bullseye AS final
 
-RUN apt-get update && apt-get install -y poppler-utils
-RUN pip install --upgrade pip
+RUN apt-get -qqy update \
+  && apt-get install -qy poppler-utils \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir --upgrade pip
 
 COPY --from=build /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
-
-COPY . /app
+COPY --exclude=data . /app
 WORKDIR /app
-RUN rm -rf data/
-RUN mkdir -p data/uploaded_papers
-RUN mkdir - data/processed_papers
+RUN mkdir -p data/uploaded_papers && mkdir data/processed_papers
 
 CMD ["python", "-m", "streamlit", "run", "Upload_Paper.py",  "--server.headless", "true"]

--- a/app_config.py
+++ b/app_config.py
@@ -1,7 +1,7 @@
 import os
 
 
-BASE_CONFIG = {
+app_config = {
     "uploaded_pdf_path": "data/uploaded_papers",
     "processed_paper_path": "data/processed_papers",
     "llm_api_keys": {},
@@ -9,23 +9,20 @@ BASE_CONFIG = {
         "app_id": os.environ.get("MATHPIX_APP_ID", ""),
         "app_key": os.environ.get("MATHPIX_APP_KEY", ""),
     },
+    "grobid_url": os.environ.get("GROBID_URL", "http://localhost:8070"),
+    "chemdataextractor_service_url": os.environ.get(
+        "CHEMDATAEXTRACTOR_SERVICE_URL", "http://localhost:8000"
+    ),
 }
 
-
-docker_config = {
-    **BASE_CONFIG,
-    "grobid_url": "http://collage-grobid-1:8070",
-    "chemdataextractor_service_url": "http://collage-chemdataextractor-1:8000",
-}
-
-sireesh_dev_config = {
-    **BASE_CONFIG,
-    "grobid_url": "http://windhoek.sp.cs.cmu.edu:8070",
-    "chemdataextractor_service_url": "http://windhoek.sp.cs.cmu.edu:8001",
-}
-
-configs = {"docker": docker_config, "sireesh_dev": sireesh_dev_config}
-
-default_config = docker_config
-
-app_config = configs.get(os.environ.get("CONFIG_NAME"), default_config)
+if predefined_config := os.environ.get("CONFIG_NAME"):
+    if predefined_config == "sireesh_dev":
+        app_config["grobid_url"] = "http://windhoek.sp.cs.cmu.edu:8070"
+        app_config[
+            "chemdataextractor_service_url"
+        ] = "http://windhoek.sp.cs.cmu.edu:8001"
+    else:  # 'docker' and everything else
+        app_config["grobid_url"] = "http://collage-grobid-1:8070"
+        app_config[
+            "chemdataextractor_service_url"
+        ] = "http://collage-chemdataextractor-1:8000"


### PR DESCRIPTION
This allows to define the location of grobid and chemdataext without modifying the source code by simply setting proper env vars (`GROBID_URL` and `CHEMDATAEXTRACTOR_SERVICE_URL`). It should be backward compatible with `CONFIG_NAME` approach.

I also trimmed the docker image a bit by removing cache for pip and apt.