### PR TITLE
Table structure troubleshooting

### DIFF
--- a/papermage_components/table_transformer_postprocessing.py
+++ b/papermage_components/table_transformer_postprocessing.py
@@ -1,3 +1,5 @@
+# Adapted from https://github.com/microsoft/table-transformer/blob/main/src/postprocess.py
+
 from collections import defaultdict
 
 from fitz import Rect

--- a/papermage_components/utils.py
+++ b/papermage_components/utils.py
@@ -10,6 +10,8 @@ from papermage.visualizers import plot_entities_on_page
 
 from papermage_components.constants import MAT_IE_TYPES
 
+from papermage_components.table_transformer_postprocessing import *
+
 
 def get_spans_from_boxes(doc: Document, boxes: list[Box]):
     intersecting_tokens = doc.intersect_by_box(query=Entity(boxes=boxes), name="tokens")
@@ -185,7 +187,7 @@ def get_table_images(table_entity: Entity, doc: Document, page_image=None, expan
 
 def visualize_table_with_boxes(table, boxes, doc, include_tokens):
     table_box = table.boxes[0]
-    table_boxes = [b for b in boxes]
+    table_boxes = [Box.from_json(b) for b in boxes]
     vis_entity = plot_entities_on_page(
         doc.pages[table_box.page].images[0],
         entities=[Entity(boxes=table_boxes)],


### PR DESCRIPTION
Added post processing steps to the table transformer to mimic the original steps in the repository (https://github.com/microsoft/table-transformer/blob/main/src/postprocess.py) 

Made changes to the existing utils.py (under papermage_components) to integrate these changes.

The algorithm uses intersection over union and intersection over area to determine the entities belonging to a bounding box.

TODO: clean-up of a few particular functions that are not required