### PR TITLE
MatIE Service Predictor + Dockerization 

### DIFF
--- a/app_config.py
+++ b/app_config.py
@@ -16,12 +16,14 @@ docker_config = {
     **BASE_CONFIG,
     "grobid_url": "http://collage-grobid-1:8070",
     "chemdataextractor_service_url": "http://collage-chemdataextractor-1:8000",
+    "matie_service_url": "http://collage-matie-1:8000",
 }
 
 sireesh_dev_config = {
     **BASE_CONFIG,
     "grobid_url": "http://windhoek.sp.cs.cmu.edu:8070",
     "chemdataextractor_service_url": "http://windhoek.sp.cs.cmu.edu:8001",
+    "matie_service_url": "http://windhoek.sp.cs.cmu.edu:8003",
 }
 
 configs = {"docker": docker_config, "sireesh_dev": sireesh_dev_config}

--- a/app_config.py
+++ b/app_config.py
@@ -1,7 +1,7 @@
 import os
 
 
-BASE_CONFIG = {
+app_config = {
     "uploaded_pdf_path": "data/uploaded_papers",
     "processed_paper_path": "data/processed_papers",
     "llm_api_keys": {},
@@ -13,18 +13,14 @@ BASE_CONFIG = {
     "chemdataextractor_service_url": os.environ.get(
         "CHEMDATAEXTRACTOR_SERVICE_URL", "http://localhost:8000"
     ),
-    "matie_service_url": os.environ.get("MATIE_SERVICE_URL", "http://localhost:8003")
+    "matie_service_url": os.environ.get("MATIE_SERVICE_URL", "http://localhost:8003"),
 }
 
 if predefined_config := os.environ.get("CONFIG_NAME"):
     if predefined_config == "sireesh_dev":
         app_config["grobid_url"] = "http://windhoek.sp.cs.cmu.edu:8070"
-        app_config[
-            "chemdataextractor_service_url"
-        ] = "http://windhoek.sp.cs.cmu.edu:8001"
+        app_config["chemdataextractor_service_url"] = "http://windhoek.sp.cs.cmu.edu:8001"
     else:  # 'docker' and everything else
         app_config["grobid_url"] = "http://collage-grobid-1:8070"
-        app_config[
-            "chemdataextractor_service_url"
-        ] = "http://collage-chemdataextractor-1:8000"
+        app_config["chemdataextractor_service_url"] = "http://collage-chemdataextractor-1:8000"
         app_config["matie_service_url"] = "http://collage-matie-1:8000"

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,11 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
 
+  matie:
+    image: gsireesh/cmu-collage-matie
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/status"]
+
   collage_interface:
     image: gsireesh/cmu-collage
     build: .
@@ -28,4 +33,5 @@ services:
     depends_on:
       - grobid
       - chemdataextractor
+      - matie
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,8 @@ services:
       - "8501:8501"
     env_file:
       - .env
+    environment:
+      CONFIG_NAME: "docker"
     volumes:
       - type: bind
         source: ./data/

--- a/local_model_config.py
+++ b/local_model_config.py
@@ -6,6 +6,7 @@ from papermage.predictors import BasePredictor
 from streamlit import cache_resource
 
 from app_config import app_config as config
+from papermage_components.matie_service_predictor import MatIEServicePredictor
 from papermage_components.table_transformer_structure_predictor import (
     TableTransformerStructurePredictor,
 )
@@ -30,6 +31,10 @@ def get_table_transformer_predictor():
 
 def get_cde_predictor():
     return ChemDataExtractorPredictor(cde_service_url=config["chemdataextractor_service_url"])
+
+
+def get_matie_predictor():
+    return MatIEServicePredictor(matIE_service_url=config["matie_service_url"])
 
 
 def get_mathpix_predictor():
@@ -57,6 +62,12 @@ MODEL_LIST: list[LocalModelInfo] = [
         model_desc="A model that uses ChemDataExtractor to tag chemicals.",
         get_model=get_cde_predictor,
         use_by_default=False,
+    ),
+    LocalModelInfo(
+        model_name="MatIE Information Extractor",
+        model_desc="A model that tags material properties and relations.",
+        get_model=get_matie_predictor,
+        use_by_default=True,
     ),
 ]
 

--- a/papermage_components/materials_recipe.py
+++ b/papermage_components/materials_recipe.py
@@ -58,6 +58,7 @@ from papermage.utils.annotate import group_by
 from papermage_components.chem_data_extractor_predictor import ChemDataExtractorPredictor
 from papermage_components.scispacy_sentence_predictor import SciSpacySentencePredictor
 from papermage_components.matIE_predictor import MatIEPredictor
+from papermage_components.matie_service_predictor import MatIEServicePredictor
 from papermage_components.reading_order_parser import GrobidReadingOrderParser
 from papermage_components.highlightParser import FitzHighlightParser
 from papermage_components.table_transformer_structure_predictor import (
@@ -101,6 +102,7 @@ class MaterialsRecipe(Recipe):
         grobid_server_url: str = "",
         xml_out_dir: str = "data/grobid_xml",
         matIE_directory: str = "",
+        matie_url: str = "",
         gpu_id: str = "0",
         dpi: int = 300,
         mathpix_token: dict = None,
@@ -134,7 +136,9 @@ class MaterialsRecipe(Recipe):
             model_name=scispacy_model,
         )
 
-        if matIE_directory:
+        if matie_url:
+            self.matIE_predictor = MatIEServicePredictor(matie_url)
+        elif matIE_directory:
             self.matIE_predictor = MatIEPredictor(
                 matIE_directory=matIE_directory,
                 gpu_id=gpu_id,

--- a/papermage_components/matie_service_predictor.py
+++ b/papermage_components/matie_service_predictor.py
@@ -48,10 +48,6 @@ def construct_document_payload(doc: Document) -> dict[str, str]:
     return input_paragraphs
 
 
-def parse_matie_service_results(results: dict) -> tuple:
-    return tuple()
-
-
 class MatIEServicePredictor(BasePredictor):
     def __init__(
         self,

--- a/papermage_components/matie_service_predictor.py
+++ b/papermage_components/matie_service_predictor.py
@@ -1,0 +1,98 @@
+from dataclasses import asdict, dataclass
+import difflib
+import os
+import re
+import subprocess
+from tempfile import TemporaryDirectory
+from typing import Dict, List, Tuple, Union
+
+from papermage.magelib import (
+    Document,
+    Entity,
+    Metadata,
+    Prediction,
+    SentencesFieldName,
+    Span,
+    TokensFieldName,
+)
+from papermage.predictors import BasePredictor
+from papermage.utils.annotate import group_by
+from pydantic import TypeAdapter
+import requests
+
+from papermage_components.constants import MAT_IE_TYPES
+from papermage_components.matIE_predictor import fix_entity_offsets, get_offset_map, MatIEEntity
+
+
+@dataclass
+class MatIERelation:
+    id: str
+    relation_type: str
+    arg1: str
+    arg2: str
+
+
+MatIEResponse = Dict[str, Dict[str, Union[str, List[MatIEEntity], List[MatIERelation]]]]
+
+
+def construct_document_payload(doc: Document) -> dict[str, str]:
+    input_paragraphs = {}
+    for paragraph in doc.reading_order_sections:
+        section_name = paragraph.metadata["section_name"]
+        paragraph_order = paragraph.metadata["paragraph_reading_order"]
+        # TODO: make this more robust!! This implicitly assumes a paragraph has only one span.
+        paragraph_text = paragraph.text.replace("\n", " ")
+        if len(paragraph.spans) != 0:
+            key = f"{section_name}_{paragraph_order}"
+            input_paragraphs[key] = paragraph_text
+    return input_paragraphs
+
+
+def parse_matie_service_results(results: dict) -> tuple:
+    return tuple()
+
+
+class MatIEServicePredictor(BasePredictor):
+    def __init__(
+        self,
+        matIE_service_url,
+    ):
+        self.service_url = matIE_service_url
+        self.preferred_layer_name = "TAGGED_ENTITIES_MatIE"
+
+    @property
+    def REQUIRED_DOCUMENT_FIELDS(self) -> List[str]:
+        return [SentencesFieldName, TokensFieldName]
+
+    @property
+    def entity_types(self):
+        return MAT_IE_TYPES
+
+    @property
+    def predictor_identifier(self):
+        return "MatIE"
+
+    def _predict(self, doc: Document) -> List[Entity]:
+        document_payload = construct_document_payload(doc)
+
+        results = requests.post(
+            self.service_url + "/annotate_strings", json=document_payload, timeout=600
+        )
+
+        annotated_content = TypeAdapter(MatIEResponse).validate_python(results.json())
+
+        fixed_entities = []
+        for (key, input_text), paragraph in zip(
+            document_payload.items(), doc.reading_order_sections
+        ):
+            para_offset = paragraph.spans[0].start
+            annotated_text = annotated_content[key]["text"]
+            offset_map = get_offset_map(input_text, annotated_text)
+            fixed_entities.extend(
+                fix_entity_offsets(annotated_content[key]["entities"], offset_map, para_offset)
+            )
+            paragraph.metadata["in_section_relations"] = [
+                asdict(r) for r in annotated_content[key]["relations"]
+            ]
+        papermage_entities = [entity.to_papermage_entity() for entity in fixed_entities]
+        return papermage_entities


### PR DESCRIPTION
This PR introduces a service-based predictor for MatIE (similar to ChemDataExtractor) and goes along with the Dockerization of MatIE into that service in [that repo](https://github.com/gsireesh/MatIE). Note that we're not pulling MatIE into this repo as a submodule or anything, so this depends on the MatIE Docker image being available for the Docker compose file for Collage to access; it should be publicly available [here](https://hub.docker.com/repository/docker/gsireesh/cmu-collage-matie/general). 

This PR also adds MatIE as a checkbox that's available in the "local models" section of the Upload Paper interface. 