### PR TITLE
Robustness fixes

### DIFF
--- a/Upload_Paper.py
+++ b/Upload_Paper.py
@@ -170,14 +170,15 @@ def process_paper(uploaded_paper: BytesIO, container: Any) -> None:
 
             with st.status("Finishing up...") as write_status:
                 try:
-                    paper_json = parsed_paper.to_json()
+                    paper_dict = parsed_paper.to_json()
+                    paper_json = json.dumps(paper_dict, indent=4)
                     with open(
                         os.path.join(
                             PARSED_PAPER_FOLDER, uploaded_paper.name.replace("pdf", "json")
                         ),
                         "w",
                     ) as f:
-                        json.dump(paper_json, f, indent=4)
+                        f.write(paper_json)
                 except Exception as e:
                     st.write(e)
                     write_status.update(state="error")

--- a/Upload_Paper.py
+++ b/Upload_Paper.py
@@ -123,6 +123,7 @@ def process_paper(uploaded_paper: BytesIO, container: Any) -> None:
                     "Your paper failed to parse. Please contact the developers,"
                     " or try a different paper."
                 )
+                return
 
             for local_predictor in st.session_state[CUSTOM_MODELS_KEY].local_predictors:
                 with st.status(f"Running model {local_predictor}") as model_status:

--- a/Upload_Paper.py
+++ b/Upload_Paper.py
@@ -181,7 +181,12 @@ def process_paper(uploaded_paper: BytesIO, container: Any) -> None:
                         f.write(paper_json)
                 except Exception as e:
                     st.write(e)
-                    write_status.update(state="error")
+                    write_status.update(
+                        state="error",
+                        label="Processed file failed to serialize. Try again, or contact the devs.",
+                    )
+
+                    return
 
             st.session_state["focus_document"] = uploaded_paper.name.replace("pdf", "json")
             st.write(

--- a/Upload_Paper.py
+++ b/Upload_Paper.py
@@ -200,7 +200,6 @@ def parse_pdf(pdf, _recipe) -> Document:
     parsed_doc_filename = os.path.join(
         PARSED_PAPER_FOLDER, os.path.basename(pdf.replace("pdf", "json"))
     )
-    st.write(parsed_doc_filename)
     if os.path.exists(parsed_doc_filename):
         with st.status("Paper has already been parsed! Using cached version...") as status:
             try:

--- a/pages/1_Summary_View.py
+++ b/pages/1_Summary_View.py
@@ -59,7 +59,7 @@ with st.sidebar:
     file_selector = st.selectbox(
         "Parsed file",
         options=file_options,
-        index=file_options.index(focus_file) if focus_file else 0,
+        index=file_options.index(focus_file) if focus_file and focus_file in file_options else 0,
     )
     st.session_state["focus_document"] = file_selector
     focus_document = load_document(file_selector)
@@ -119,26 +119,34 @@ with entities_column:
         )
 
     with heuristics_tab:
-        doc_graph = create_document_graph(focus_document, str(focus_document.symbols[:50]))
+        if getattr(focus_document, "TAGGED_ENTITIES_MatIE"):
+            doc_graph = create_document_graph(focus_document, str(focus_document.symbols[:50]))
 
-        st.write("## Most common materials")
-        most_frequent_materials = get_most_common_materials(focus_document.TAGGED_ENTITIES_MatIE)
-        cols = st.columns(len(most_frequent_materials))
-        for i, ((material, count), col) in enumerate(zip(most_frequent_materials, cols)):
-            st.metric(f"#{i + 1}", material, f"{count} mentions")
+            st.write("## Most common materials")
+            most_frequent_materials = get_most_common_materials(
+                focus_document.TAGGED_ENTITIES_MatIE
+            )
+            cols = st.columns(len(most_frequent_materials))
+            for i, ((material, count), col) in enumerate(zip(most_frequent_materials, cols)):
+                st.metric(f"#{i + 1}", material, f"{count} mentions")
 
-        compositions_table = get_composition_table(focus_document.TAGGED_ENTITIES_MatIE)
-        if not compositions_table.empty:
-            st.write("## Discovered Compositions")
-            st.dataframe(compositions_table.style.background_gradient(cmap="Blues", axis=None))
+            compositions_table = get_composition_table(focus_document.TAGGED_ENTITIES_MatIE)
+            if not compositions_table.empty:
+                st.write("## Discovered Compositions")
+                st.dataframe(compositions_table.style.background_gradient(cmap="Blues", axis=None))
 
-        st.write("## Discovered Properties")
-        property_table = get_property_table(doc_graph)
-        st.dataframe(property_table)
+            st.write("## Discovered Properties")
+            property_table = get_property_table(doc_graph)
+            st.dataframe(property_table)
 
-        st.write("## Discovered Synthesis Methods")
-        synthesis_table = get_synthesis_method_table(doc_graph)
-        st.dataframe(synthesis_table)
+            st.write("## Discovered Synthesis Methods")
+            synthesis_table = get_synthesis_method_table(doc_graph)
+            st.dataframe(synthesis_table)
+        else:
+            st.write(
+                "MatIE has not been run on this paper. Please run MatIE to get materials "
+                "heuristics."
+            )
 
 
 with table_column:

--- a/pages/2_Annotations_View.py
+++ b/pages/2_Annotations_View.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import spacy_streamlit
-from streamlit_dimensions import st_dimensions
 from streamlit_image_coordinates import streamlit_image_coordinates
 
 
@@ -207,20 +206,14 @@ with doc_vis_column:
             focus_page,
             selectable_layers=["reading_order_sections", TablesFieldName],
         )
-    page_width, page_height = highlighted_image.pilimage.size
-    ratio = page_height / page_width
-
-    image_width = st_dimensions(key="doc_vis")["width"]
-
-    image_height = image_width * ratio
 
     image_coords = streamlit_image_coordinates(
-        highlighted_image.pilimage, key="annotation_page_image", width=image_width
+        highlighted_image.pilimage, key="annotation_page_image", use_column_width="always"
     )
 
     if image_coords is not None:
-        x = image_coords["x"] / image_width
-        y = image_coords["y"] / image_height
+        x = image_coords["x"] / image_coords["width"]
+        y = image_coords["y"] / image_coords["height"]
 
         click_sections = focus_document.find(
             Box(x - BOX_PADDING / 2, y - BOX_PADDING / 2, BOX_PADDING, BOX_PADDING, focus_page),

--- a/pages/2_Annotations_View.py
+++ b/pages/2_Annotations_View.py
@@ -37,7 +37,7 @@ with st.sidebar:
     file_selector = st.selectbox(
         "Parsed file",
         options=file_options,
-        index=file_options.index(focus_file) if focus_file else 0,
+        index=file_options.index(focus_file) if focus_file and focus_file in file_options else 0,
     )
     st.session_state["focus_document"] = file_selector
     focus_document = load_document(file_selector)

--- a/pages/3_Inspection_View.py
+++ b/pages/3_Inspection_View.py
@@ -1,22 +1,11 @@
-import pandas as pd
-import spacy_streamlit
-from streamlit_dimensions import st_dimensions
 from streamlit_image_coordinates import streamlit_image_coordinates
 
-from papermage import Box, Entity
-from papermage.visualizers import plot_entities_on_page
-
-from papermage_components.constants import (
-    HIGHLIGHT_COLORS,
-    HIGHLIGHT_TYPES,
-    MAT_IE_COLORS,
-    MAT_IE_TYPES,
-)
+from interface_utils import *
+from papermage import Box
 from papermage_components.utils import (
-    visualize_highlights,
     get_table_images,
 )
-from interface_utils import *
+
 
 st.set_page_config(layout="wide")
 
@@ -82,19 +71,13 @@ with doc_vis_column:
             focus_document, focus_page, selectable_layers=[focus_layer]
         )
 
-    page_width, page_height = highlighted_image.pilimage.size
-    ratio = page_height / page_width
-
-    image_width = st_dimensions(key="doc_vis")["width"]
-    image_height = image_width * ratio
-
     image_coords = streamlit_image_coordinates(
-        highlighted_image.pilimage, key="annotation_page_image", width=image_width
+        highlighted_image.pilimage, key="annotation_page_image", use_column_width="always"
     )
 
     if image_coords is not None:
-        x = image_coords["x"] / image_width
-        y = image_coords["y"] / image_height
+        x = image_coords["x"] / image_coords["width"]
+        y = image_coords["y"] / image_coords["height"]
 
         st.session_state["clicked_coordinates"] = (x, y, focus_page)
 

--- a/pages/3_Inspection_View.py
+++ b/pages/3_Inspection_View.py
@@ -45,7 +45,7 @@ with st.sidebar:  # .form("File selector"):
     file_selector = st.selectbox(
         "Parsed file",
         options=file_options,
-        index=file_options.index(focus_file) if focus_file else 0,
+        index=file_options.index(focus_file) if focus_file and focus_file in file_options else 0,
     )
     st.session_state["focus_document"] = file_selector
     focus_document = load_document(file_selector)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,7 @@ PyMuPDF==1.23.25
 spacy-streamlit==1.0.6
 streamlit==1.36.0
 streamlit-extras==0.4.3
-streamlit-dimensions==0.0.1
-streamlit-image-coordinates==0.1.6
+streamlit-image-coordinates==0.2.0
 huggingface-hub~=0.23.4
 transformers~=4.38.2
 numpy~=1.26.0


### PR DESCRIPTION
This PR includes several fixes to handle failure cases and other sharp edges:

- If paper parsing (i.e. PDF parsing, grobid, VILA) fails, the paper stops processing, and none of the subsequent steps are run. You now get a nice error message in the processing column that asks you to contact the devs. 
- If a file fails to serialize, we end the processing, and don't set the focus document or display the go to annotations button.
- We separate serializing a document to json to actually writing it to disk, so that if the serialization fails, we don't open/leave around an awkward empty file that causes problems for the rest of the interface.  
- We no longer print the filename of the processed file. 
- If the focus_file is not in the file selector, it will default to the first file in the directory, thus not softlocking the interface. This should no longer matter if we're not setting the focus file to things that fail to process, but it's nice to have the redundancy, I guess. 
- We update the `streamlit_image_coordinates` package, which now allows us to dynamically set width according to the column that the widget is in, rather than setting it statically. This removes the dependency on `streamlit-coordinates`, which caused the transient indexing-to-none error that would appear when entering the annotations/inspection view, or switching pages.
